### PR TITLE
Do not build docker-credential-ecr-login

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-FROM public.ecr.aws/docker/library/golang:1.16-stretch AS ecr-login
-
-RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
-
 FROM public.ecr.aws/docker/library/openjdk:11-jdk-buster
 
 WORKDIR /app
@@ -15,5 +11,3 @@ COPY hadoop-${HADOOP_VERSION}-libs.tar.gz .
 RUN tar zxf hadoop-${HADOOP_VERSION}-libs.tar.gz && \
     cp lib*.so /usr/lib/ && \
     rm -f hadoop-${HADOOP_VERSION}-libs.tar.gz lib*.so
-
-COPY --from=ecr-login /go/bin/docker-credential-ecr-login /usr/local/bin/


### PR DESCRIPTION
I believe docker-credential-ecr-login is not needed *in* the image, it is used on building the image.